### PR TITLE
fix element to select for dropdown parent

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -88,7 +88,7 @@ document.addEventListener('dal-init-function', function () {
             ajax: ajax,
             with: null,
             tags: Boolean($element.attr('data-tags')),
-            dropdownParent: $element.attr('data-dropdown-parent') ? $(element.attr('data-dropdown-parent')) : $(document.body),
+            dropdownParent: $element.attr('data-dropdown-parent') ? $($element.attr('data-dropdown-parent')) : $(document.body),
         });
 
         $element.on('select2:selecting', function (e) {


### PR DESCRIPTION
When define select2 with dropdownParent attribute, an error "element.attr is not a function" appears.